### PR TITLE
Expand golden_arrow: Fluff Slop

### DIFF
--- a/code/game/area/golden_arrow.dm
+++ b/code/game/area/golden_arrow.dm
@@ -48,6 +48,10 @@
 
 /area/golden_arrow/prep_hallway
 	name = "\improper Prep Hallway"
+	icon_state = "starboard"
+
+/area/golden_arrow/port_hallway
+	name = "\improper Port Hallway"
 	icon_state = "port"
 
 /area/golden_arrow/platoon_sergeant

--- a/maps/map_files/golden_arrow/golden_arrow.dmm
+++ b/maps/map_files/golden_arrow/golden_arrow.dmm
@@ -358,9 +358,6 @@
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/cryo_cells)
-"aaI" = (
-/turf/closed/wall/almayer/outer,
-/area/golden_arrow/medical)
 "aaJ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S";
@@ -871,6 +868,9 @@
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/motor_pool)
+"abP" = (
+/turf/closed/wall/almayer/outer,
+/area/golden_arrow/port_hallway)
 "abQ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/almayer/cargo,
@@ -897,6 +897,9 @@
 /obj/structure/machinery/landinglight/ds1/delaytwo,
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/hangar)
+"abU" = (
+/turf/open/floor/almayer/cargo_arrow/north,
+/area/golden_arrow/port_hallway)
 "abV" = (
 /turf/open/floor/almayer/uscm/directional/up_down/northwest,
 /area/golden_arrow/hangar)
@@ -935,6 +938,12 @@
 	},
 /turf/open/floor/almayer/cargo_arrow/east,
 /area/golden_arrow/hangar)
+"abZ" = (
+/obj/structure/pipes/vents/pump{
+	dir = 1
+	},
+/turf/open/floor/almayer/cargo_arrow/north,
+/area/golden_arrow/port_hallway)
 "aca" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 8
@@ -954,6 +963,24 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/cryo_cells)
+"acc" = (
+/obj/structure/machinery/door/poddoor/almayer/locked{
+	name = "\improper Hangar Lockdown Blast Door";
+	dir = 2
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/golden_arrow/port_hallway)
+"acd" = (
+/obj/structure/machinery/door/poddoor/almayer/locked{
+	name = "\improper Hangar Lockdown Blast Door";
+	dir = 2
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/golden_arrow/port_hallway)
 "ace" = (
 /obj/structure/surface/table/almayer,
 /obj/item/clothing/mask/cigarette/cigar{
@@ -989,6 +1016,28 @@
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/platoonprep)
+"acf" = (
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "cargo_arrow"
+	},
+/turf/open/floor/almayer/edge/southwest,
+/area/golden_arrow/port_hallway)
+"acg" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "cargo_arrow"
+	},
+/turf/open/floor/almayer/edge/southeast,
+/area/golden_arrow/port_hallway)
 "ach" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
@@ -1002,6 +1051,16 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/hangar)
+"acj" = (
+/obj/structure/machinery/light/double/blue/golden_arrow{
+	dir = 8;
+	light_power = 0.3
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/edge/west,
+/area/golden_arrow/port_hallway)
 "ack" = (
 /obj/structure/bed{
 	can_buckle = 0
@@ -1019,10 +1078,44 @@
 	},
 /turf/open/floor/almayer/edge/southwest,
 /area/golden_arrow/dorms)
+"acl" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/structure/machinery/light/double/blue/golden_arrow{
+	dir = 4;
+	light_power = 0.3
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
+"acm" = (
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/edge/west,
+/area/golden_arrow/port_hallway)
+"acn" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
 "aco" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/hangar)
+"acp" = (
+/obj/structure/machinery/light/double/blue/golden_arrow{
+	dir = 8;
+	light_power = 0.7
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "acq" = (
 /obj/structure/surface/table/almayer,
 /obj/item/toy/deck,
@@ -1048,6 +1141,9 @@
 	},
 /turf/open/floor/almayer/edge/smooth,
 /area/golden_arrow/platoonprep)
+"acu" = (
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "acv" = (
 /obj/effect/landmark/nightmare{
 	insert_tag = "dorms"
@@ -1070,6 +1166,12 @@
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/platoonprep)
+"acy" = (
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "acz" = (
 /obj/vehicle/powerloader{
 	dir = 1
@@ -1123,6 +1225,16 @@
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/hangar)
+"acC" = (
+/obj/structure/machinery/light/double/blue/golden_arrow{
+	dir = 4;
+	light_power = 0.7
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "acD" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
@@ -1130,6 +1242,30 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/golden_arrow/hangar)
+"acE" = (
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/edge/west,
+/area/golden_arrow/port_hallway)
+"acF" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/turf/open/floor/almayer/edge/east,
+/area/golden_arrow/port_hallway)
+"acG" = (
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "acH" = (
 /obj/structure/machinery/door/airlock/almayer/medical/glass{
 	dir = 1
@@ -1137,6 +1273,25 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/dark_sterile,
 /area/golden_arrow/medical)
+"acI" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer/orange/north,
+/area/golden_arrow/port_hallway)
+"acJ" = (
+/obj/structure/pipes/standard/manifold/hidden/supply,
+/turf/open/floor/almayer/orange/north,
+/area/golden_arrow/port_hallway)
+"acK" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/orange/north,
+/area/golden_arrow/port_hallway)
 "acL" = (
 /obj/structure/surface/table/almayer,
 /obj/item/prop/colony/game{
@@ -1145,6 +1300,21 @@
 	},
 /turf/open/floor/almayer/edge,
 /area/golden_arrow/dorms)
+"acM" = (
+/obj/structure/pipes/vents/scrubber{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"acN" = (
+/obj/structure/surface/rack,
+/obj/item/tool/screwdriver,
+/obj/item/prop/helmetgarb/gunoil,
+/turf/open/floor/almayer/plate,
+/area/golden_arrow/port_hallway)
 "acO" = (
 /obj/structure/machinery/shower{
 	dir = 4
@@ -1196,6 +1366,21 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/hangar)
+"acU" = (
+/obj/structure/surface/rack,
+/obj/item/ammo_magazine/rifle/m41aMK1{
+	pixel_x = -5;
+	current_rounds = 0
+	},
+/obj/item/ammo_magazine/rifle/m41aMK1{
+	current_rounds = 0
+	},
+/obj/item/ammo_magazine/rifle/m41aMK1{
+	pixel_x = 5;
+	current_rounds = 0
+	},
+/turf/open/floor/almayer/plate,
+/area/golden_arrow/port_hallway)
 "acV" = (
 /obj/effect/landmark/start/bridge,
 /obj/effect/landmark/late_join/alpha,
@@ -1208,6 +1393,9 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/golden_arrow/cryo_cells)
+"acW" = (
+/turf/closed/wall/almayer,
+/area/golden_arrow/port_hallway)
 "acX" = (
 /obj/structure/sign/safety/galley{
 	pixel_y = 28
@@ -1220,6 +1408,9 @@
 	},
 /turf/open/floor/almayer/edge/northwest,
 /area/golden_arrow/prep_hallway)
+"acY" = (
+/turf/open/floor/almayer/edge/west,
+/area/golden_arrow/port_hallway)
 "acZ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -1235,6 +1426,24 @@
 	},
 /turf/open/floor/almayer/edge/northwest,
 /area/golden_arrow/platoonarmory)
+"adb" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"adc" = (
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice1";
+	layer = 5.2;
+	pixel_y = -18
+	},
+/turf/open/floor/almayer/edge,
+/area/golden_arrow/port_hallway)
 "add" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -1245,6 +1454,12 @@
 	},
 /turf/open/floor/almayer/edge/smooth/endcap_right/east,
 /area/golden_arrow/supply)
+"ade" = (
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/edge,
+/area/golden_arrow/port_hallway)
 "adf" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/cable{
@@ -1260,6 +1475,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer/edge/smooth/north,
 /area/golden_arrow/lower_cargo)
+"adh" = (
+/obj/structure/machinery/light/double/blue/golden_arrow,
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/edge,
+/area/golden_arrow/port_hallway)
+"adi" = (
+/obj/structure/cable{
+	layer = 2.36
+	},
+/obj/structure/machinery/power/apc/almayer/south,
+/turf/open/floor/almayer/edge,
+/area/golden_arrow/port_hallway)
 "adj" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 1
@@ -1278,6 +1507,9 @@
 "adl" = (
 /turf/open/floor/almayer/edge/north,
 /area/golden_arrow/platoonarmory)
+"adm" = (
+/turf/open/floor/almayer/edge,
+/area/golden_arrow/port_hallway)
 "adn" = (
 /obj/effect/decal/strata_decals/grime/grime2{
 	dir = 8
@@ -1322,6 +1554,16 @@
 	},
 /turf/open/floor/almayer/edge/smooth/east,
 /area/golden_arrow/hangar)
+"ads" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/edge/southeast,
+/area/golden_arrow/port_hallway)
 "adt" = (
 /obj/structure/sign/safety/water{
 	pixel_x = 11;
@@ -1329,6 +1571,14 @@
 	},
 /turf/closed/wall/almayer,
 /area/golden_arrow/cryo_cells)
+"adu" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/machinery/door/airlock/multi_tile/almayer/almayer/glass{
+	name = "\improper Muster Point";
+	dir = 2
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/golden_arrow/port_hallway)
 "adv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -1337,6 +1587,16 @@
 	},
 /turf/open/floor/almayer/edge/smooth/north,
 /area/golden_arrow/motor_pool)
+"adw" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "adx" = (
 /obj/structure/platform{
 	dir = 8;
@@ -1412,6 +1672,12 @@
 	},
 /turf/open/floor/almayer/edge/smooth/east,
 /area/golden_arrow/cryo_cells)
+"adF" = (
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/orange/north,
+/area/golden_arrow/port_hallway)
 "adG" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt{
@@ -1460,6 +1726,17 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/motor_pool)
+"adM" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/orange/north,
+/area/golden_arrow/port_hallway)
+"adN" = (
+/obj/structure/machinery/light/double/blue/golden_arrow,
+/turf/open/floor/almayer/redfull,
+/area/golden_arrow/port_hallway)
+"adO" = (
+/turf/open/floor/almayer/plating/northeast,
+/area/golden_arrow/port_hallway)
 "adP" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -1480,6 +1757,18 @@
 	},
 /turf/open/floor/almayer/mono,
 /area/golden_arrow/motor_pool)
+"adR" = (
+/obj/structure/target,
+/obj/structure/machinery/light/double/blue/golden_arrow,
+/turf/open/floor/almayer/redfull,
+/area/golden_arrow/port_hallway)
+"adS" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/turf/open/floor/almayer/plating/northeast,
+/area/golden_arrow/port_hallway)
 "adT" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
@@ -1514,6 +1803,32 @@
 "adW" = (
 /turf/open/floor/almayer/edge/smooth/endcap_right/west,
 /area/golden_arrow/cryo_cells)
+"adX" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/obj/structure/sign/safety/two{
+	pixel_y = -22
+	},
+/obj/structure/machinery/light/double/blue/golden_arrow,
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"adY" = (
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/obj/structure/machinery/camera/autoname/golden_arrow{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
+"adZ" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/golden_arrow/port_hallway)
 "aea" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -1557,6 +1872,10 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/golden_arrow/medical)
+"aee" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/golden_arrow/port_hallway)
 "aef" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
@@ -1573,6 +1892,21 @@
 	},
 /turf/open/floor/almayer/edge/smooth/north,
 /area/golden_arrow/hangar)
+"aeh" = (
+/obj/structure/machinery/camera/autoname/golden_arrow{
+	dir = 4
+	},
+/turf/open/floor/almayer/edge/west,
+/area/golden_arrow/port_hallway)
+"aei" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2-4"
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "aej" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
@@ -1597,6 +1931,23 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/golden_arrow/cryo_cells)
+"aem" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice2";
+	pixel_y = 14
+	},
+/obj/structure/prop/invuln/lattice_prop{
+	icon_state = "lattice3";
+	pixel_y = -18
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
 "aen" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
@@ -1608,15 +1959,120 @@
 "aeo" = (
 /turf/open/floor/almayer,
 /area/golden_arrow/dorms)
+"aep" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/safety/security{
+	pixel_y = 28
+	},
+/obj/structure/sign/safety/restrictedarea{
+	pixel_x = 14;
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
+"aeq" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning";
+	dir = 1
+	},
+/obj/structure/pipes/standard/manifold/hidden/supply,
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "aer" = (
-/turf/open/floor/almayer/cargo_arrow/north,
-/area/golden_arrow/prep_hallway)
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "cargo_arrow";
+	dir = 1
+	},
+/turf/open/floor/almayer/edge/northwest,
+/area/golden_arrow/port_hallway)
+"aes" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/light/double/blue/golden_arrow{
+	dir = 1
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
+"aet" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
+"aeu" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/heavyduty/west,
+/obj/structure/cable{
+	icon_state = "0-2";
+	layer = 2.36
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/edge/north,
+/area/golden_arrow/port_hallway)
 "aev" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
 	},
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/motor_pool)
+"aew" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	name = "General Listening Channel";
+	pixel_y = 28;
+	freerange = 1
+	},
+/turf/open/floor/almayer/edge/north,
+/area/golden_arrow/port_hallway)
+"aex" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning";
+	dir = 4
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/edge/northeast,
+/area/golden_arrow/port_hallway)
 "aey" = (
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/golden_arrow/hangar)
@@ -1630,6 +2086,13 @@
 "aeA" = (
 /turf/open/floor/almayer/edge,
 /area/golden_arrow/prep_hallway)
+"aeB" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer/test_floor4,
+/area/golden_arrow/port_hallway)
 "aeC" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
@@ -1644,6 +2107,19 @@
 	},
 /turf/open/floor/almayer/edge/smooth/southeast,
 /area/golden_arrow/platoon_commander_rooms)
+"aeD" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning";
+	dir = 8
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "aeE" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
@@ -1701,6 +2177,24 @@
 	},
 /turf/open/floor/almayer/edge/smooth/southwest,
 /area/golden_arrow/platoon_commander_rooms)
+"aeI" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"aeJ" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/orange/north,
+/area/golden_arrow/port_hallway)
 "aeK" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/cable/heavyduty{
@@ -1740,6 +2234,9 @@
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/dorms)
+"aeN" = (
+/turf/open/floor/almayer/orange/north,
+/area/golden_arrow/port_hallway)
 "aeO" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	name = "\improper Lower Storage Bay Five Blast Door";
@@ -1751,6 +2248,14 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/golden_arrow/lower_cargo)
+"aeP" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/structure/target,
+/turf/open/floor/almayer/redfull,
+/area/golden_arrow/port_hallway)
 "aeQ" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/prop/almayer/CICmap{
@@ -1788,6 +2293,13 @@
 	},
 /turf/open/floor/almayer/cargo_arrow/north,
 /area/golden_arrow/hangar)
+"aeS" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/turf/open/floor/almayer/plating/northeast,
+/area/golden_arrow/port_hallway)
 "aeT" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -1824,9 +2336,41 @@
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/hangar)
+"aeY" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plating/northeast,
+/area/golden_arrow/port_hallway)
 "aeZ" = (
 /turf/open/floor/almayer/edge/smooth/north,
 /area/golden_arrow/motor_pool)
+"afa" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/turf/open/floor/almayer/redfull,
+/area/golden_arrow/port_hallway)
+"afb" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "N";
+	pixel_y = 1
+	},
+/turf/open/floor/almayer/plating/northeast,
+/area/golden_arrow/port_hallway)
+"afc" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "afd" = (
 /obj/structure/barricade/handrail,
 /obj/structure/barricade/handrail{
@@ -1834,6 +2378,9 @@
 	},
 /turf/open/floor/almayer/mono,
 /area/golden_arrow/motor_pool)
+"afe" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
 "aff" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "cargo_arrow";
@@ -1841,6 +2388,10 @@
 	},
 /turf/open/floor/almayer/edge/east,
 /area/golden_arrow/lower_cargo)
+"afg" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer/plate,
+/area/golden_arrow/port_hallway)
 "afh" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -1854,6 +2405,21 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/cryo_cells)
+"afi" = (
+/obj/structure/surface/table/almayer,
+/turf/open/floor/almayer/plate,
+/area/golden_arrow/port_hallway)
+"afj" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
 "afk" = (
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/squad_prep{
 	req_one_access = list();
@@ -1926,6 +2492,17 @@
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/motor_pool)
+"afp" = (
+/obj/structure/machinery/door/airlock/almayer/security{
+	name = "\improper Security Checkpoint";
+	dir = 2
+	},
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/machinery/door/firedoor/border_only/almayer{
+	dir = 1
+	},
+/turf/open/floor/almayer/test_floor4,
+/area/golden_arrow/port_hallway)
 "afq" = (
 /obj/structure/disposalpipe/segment{
 	icon_state = "pipe-c";
@@ -1936,6 +2513,10 @@
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/lower_cargo)
+"afr" = (
+/obj/structure/window/framed/almayer,
+/turf/open/floor/plating,
+/area/golden_arrow/port_hallway)
 "afs" = (
 /obj/structure/largecrate/supply/medicine/medkits{
 	pixel_x = -4;
@@ -1956,6 +2537,9 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/hangar)
+"aft" = (
+/turf/open/floor/almayer/plate,
+/area/golden_arrow/port_hallway)
 "afu" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -1970,6 +2554,13 @@
 /obj/structure/machinery/prop/almayer/CICmap/table/horizontal/segment/four,
 /turf/open/floor/almayer/mono,
 /area/golden_arrow/briefing)
+"afw" = (
+/obj/structure/barricade/plasteel{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plate,
+/area/golden_arrow/port_hallway)
 "afx" = (
 /obj/structure/machinery/door/poddoor/railing,
 /obj/effect/decal/strata_decals/grime/grime1{
@@ -2013,10 +2604,53 @@
 	},
 /turf/open/floor/almayer/edge/smooth/north,
 /area/golden_arrow/hangar)
+"afC" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
 "afD" = (
 /obj/structure/machinery/light/double/blue/golden_arrow,
 /turf/open/floor/almayer/edge/smooth/corner/west,
 /area/golden_arrow/motor_pool)
+"afE" = (
+/obj/structure/machinery/light{
+	dir = 4
+	},
+/obj/structure/surface/table/almayer,
+/turf/open/floor/almayer/plate,
+/area/golden_arrow/port_hallway)
+"afF" = (
+/obj/structure/machinery/light/double/blue/golden_arrow{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/edge/west,
+/area/golden_arrow/port_hallway)
+"afG" = (
+/obj/structure/machinery/vending/security{
+	req_access = list();
+	req_one_access_txt = "8;12;39;40"
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/red/southwest,
+/area/golden_arrow/port_hallway)
+"afH" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning"
+	},
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/red,
+/area/golden_arrow/port_hallway)
 "afI" = (
 /obj/structure/machinery/shower{
 	pixel_y = 16
@@ -2050,6 +2684,15 @@
 	},
 /turf/open/floor/almayer/edge/smooth/west,
 /area/golden_arrow/hangar)
+"afK" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/red,
+/area/golden_arrow/port_hallway)
 "afL" = (
 /obj/structure/bed{
 	can_buckle = 0
@@ -2067,6 +2710,12 @@
 	},
 /turf/open/floor/almayer/edge/northwest,
 /area/golden_arrow/dorms)
+"afM" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 9
+	},
+/turf/open/floor/almayer/red,
+/area/golden_arrow/port_hallway)
 "afN" = (
 /turf/open/floor/almayer/cargo_arrow/east,
 /area/golden_arrow/hangar)
@@ -2101,6 +2750,9 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/golden_arrow/prep_hallway)
+"afS" = (
+/turf/open/floor/almayer/red/southeast,
+/area/golden_arrow/port_hallway)
 "afT" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 8
@@ -2127,6 +2779,10 @@
 	},
 /turf/open/floor/almayer/edge/smooth,
 /area/golden_arrow/hangar)
+"afV" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "afW" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -2141,6 +2797,14 @@
 	},
 /turf/open/floor/almayer/sterile_green_side/east,
 /area/golden_arrow/medical)
+"afY" = (
+/obj/item/device/radio/intercom{
+	name = "General Listening Channel";
+	pixel_x = 28;
+	freerange = 1
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "afZ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -2149,6 +2813,14 @@
 	},
 /turf/closed/wall/almayer,
 /area/golden_arrow/platoonarmory)
+"aga" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/structure/target,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/redfull,
+/area/golden_arrow/port_hallway)
 "agb" = (
 /obj/structure/machinery/telecomms/relay/preset/tower,
 /turf/open/floor/almayer,
@@ -2204,6 +2876,13 @@
 	},
 /turf/open/floor/almayer/edge/southeast,
 /area/golden_arrow/dorms)
+"agg" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer/plating/northeast,
+/area/golden_arrow/port_hallway)
 "agh" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /obj/structure/cable/heavyduty{
@@ -2217,6 +2896,12 @@
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/cryo_cells)
+"agi" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer/plating/northeast,
+/area/golden_arrow/port_hallway)
 "agj" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
@@ -2227,6 +2912,37 @@
 /obj/structure/barricade/handrail,
 /turf/open/floor/almayer,
 /area/golden_arrow/motor_pool)
+"agk" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer/redfull,
+/area/golden_arrow/port_hallway)
+"agl" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "E";
+	pixel_x = 1
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "S"
+	},
+/turf/open/floor/almayer/plating/northeast,
+/area/golden_arrow/port_hallway)
+"agm" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"agn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning";
+	dir = 4
+	},
+/turf/open/floor/almayer/plate,
+/area/golden_arrow/port_hallway)
 "ago" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "cargo"
@@ -2236,6 +2952,14 @@
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/lower_cargo)
+"agp" = (
+/obj/structure/machinery/door/airlock/multi_tile/almayer/generic{
+	name = "\improper Firing Range";
+	dir = 2
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer/test_floor4,
+/area/golden_arrow/port_hallway)
 "agq" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
@@ -2245,6 +2969,42 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/hangar)
+"agr" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning";
+	dir = 8
+	},
+/turf/open/floor/almayer/edge/west,
+/area/golden_arrow/port_hallway)
+"ags" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"agt" = (
+/obj/structure/machinery/light/double/blue/golden_arrow{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/red/west,
+/area/golden_arrow/port_hallway)
+"agu" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/structure/pipes/vents/pump,
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "agv" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 1
@@ -2254,12 +3014,40 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/golden_arrow/hangar)
+"agw" = (
+/obj/structure/pipes/vents/scrubber,
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"agx" = (
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/red/east,
+/area/golden_arrow/port_hallway)
 "agy" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer/edge/smooth/north,
 /area/golden_arrow/hangar)
+"agz" = (
+/obj/structure/machinery/camera/autoname/golden_arrow{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"agA" = (
+/obj/structure/window/reinforced/ultra{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "agB" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SE-out"
@@ -2286,6 +3074,11 @@
 "agE" = (
 /turf/open/floor/almayer/edge/smooth/west,
 /area/golden_arrow/platoonprep)
+"agF" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/window/reinforced/ultra,
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "agG" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
@@ -2336,6 +3129,40 @@
 	},
 /turf/open/floor/almayer/edge/north,
 /area/golden_arrow/dorms)
+"agJ" = (
+/obj/item/prop/tableflag,
+/obj/structure/surface/table/almayer,
+/obj/structure/window/reinforced/ultra,
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"agK" = (
+/obj/structure/window/reinforced/ultra{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"agL" = (
+/obj/structure/surface/table/almayer,
+/obj/item/paper_bin/uscm{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/tool/pen{
+	pixel_x = -12;
+	pixel_y = -6
+	},
+/obj/item/reagent_container/food/drinks/coffeecup/uscm{
+	pixel_x = -9;
+	pixel_y = 8
+	},
+/obj/item/folder/red{
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "agM" = (
 /obj/structure/machinery/light/double/blue/golden_arrow{
 	light_power = 0.7
@@ -2366,15 +3193,25 @@
 	},
 /turf/open/floor/almayer/edge/smooth,
 /area/golden_arrow/hangar)
-"agR" = (
-/obj/structure/pipes/standard/simple/hidden/supply{
-	dir = 9
+"agQ" = (
+/obj/structure/machinery/light/double/blue/golden_arrow,
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
 	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"agR" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
 /turf/open/floor/plating/plating_catwalk,
-/area/golden_arrow/prep_hallway)
+/area/golden_arrow/port_hallway)
 "agS" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/machinery/door/poddoor/shutters/almayer{
@@ -2392,6 +3229,13 @@
 	},
 /turf/open/floor/almayer/edge/smooth/west,
 /area/golden_arrow/hangar)
+"agU" = (
+/obj/structure/machinery/light/double/blue/golden_arrow{
+	dir = 1;
+	light_power = 0.3
+	},
+/turf/open/floor/almayer/redfull,
+/area/golden_arrow/port_hallway)
 "agV" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 8
@@ -2408,6 +3252,15 @@
 	},
 /turf/open/floor/almayer/edge/east,
 /area/golden_arrow/dorms)
+"agW" = (
+/obj/structure/target,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/machinery/light/double/blue/golden_arrow{
+	dir = 1;
+	light_power = 0.3
+	},
+/turf/open/floor/almayer/redfull,
+/area/golden_arrow/port_hallway)
 "agX" = (
 /obj/structure/machinery/door_control/brbutton{
 	name = "vehicle bay blast door control";
@@ -2425,6 +3278,19 @@
 	},
 /turf/open/floor/almayer/cargo_arrow/west,
 /area/golden_arrow/hangar)
+"agZ" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/obj/structure/sign/safety/one{
+	pixel_y = 22
+	},
+/obj/structure/machinery/light/double/blue/golden_arrow{
+	dir = 1;
+	light_power = 0.3
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "aha" = (
 /obj/structure/surface/table/almayer,
 /obj/item/trash/cigbutt/cigarbutt{
@@ -2466,6 +3332,32 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/hangar)
+"ahd" = (
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
+"ahe" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/open/floor/almayer/plate,
+/area/golden_arrow/port_hallway)
+"ahf" = (
+/obj/structure/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning";
+	dir = 4
+	},
+/turf/open/floor/almayer/plate,
+/area/golden_arrow/port_hallway)
 "ahg" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -2474,6 +3366,13 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer/cargo_arrow,
 /area/golden_arrow/hangar)
+"ahh" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/turf/open/floor/almayer/test_floor4,
+/area/golden_arrow/port_hallway)
 "ahi" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -2544,6 +3443,16 @@
 /obj/item/reagent_container/food/snacks/flour,
 /turf/open/floor/almayer/dark_sterile,
 /area/golden_arrow/cryo_cells)
+"ahn" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning";
+	dir = 8
+	},
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 8
+	},
+/turf/open/floor/almayer/edge/west,
+/area/golden_arrow/port_hallway)
 "aho" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
@@ -2559,6 +3468,45 @@
 	},
 /turf/open/floor/plating,
 /area/golden_arrow/hangar)
+"ahq" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
+"ahr" = (
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/item/storage/box/flashbangs{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/restraint/handcuffs,
+/obj/item/storage/firstaid/regular,
+/obj/structure/sign/safety/terminal{
+	pixel_x = -17
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/red/northwest,
+/area/golden_arrow/port_hallway)
+"ahs" = (
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/structure/machinery/computer/squad_changer{
+	pixel_x = -9;
+	req_access = list(0);
+	req_one_access_txt = "19;12"
+	},
+/obj/structure/machinery/computer/card{
+	pixel_x = 9;
+	req_access = list();
+	req_one_access_txt = "19;12"
+	},
+/turf/open/floor/almayer/red/north,
+/area/golden_arrow/port_hallway)
 "aht" = (
 /obj/structure/bed/chair/comfy,
 /obj/effect/decal/cleanable/dirt{
@@ -2566,6 +3514,24 @@
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/cryo_cells)
+"ahu" = (
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/item/storage/box/handcuffs{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/box/ids{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/storage/box/handcuffs,
+/turf/open/floor/almayer/red/north,
+/area/golden_arrow/port_hallway)
+"ahv" = (
+/obj/structure/machinery/vending/snack,
+/obj/structure/machinery/camera/autoname/golden_arrow,
+/turf/open/floor/almayer/red/north,
+/area/golden_arrow/port_hallway)
 "ahw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
@@ -2574,6 +3540,25 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/golden_arrow/lower_cargo)
+"ahx" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "pottedplant_22";
+	pixel_x = -13
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/red/northeast,
+/area/golden_arrow/port_hallway)
+"ahy" = (
+/obj/structure/pipes/vents/pump{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "ahz" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "door_warning";
@@ -2614,12 +3599,48 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/golden_arrow/hangar)
+"ahC" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/window/reinforced/ultra{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"ahD" = (
+/obj/structure/pipes/standard/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"ahE" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "ahF" = (
 /obj/structure/machinery/door/poddoor/railing{
 	id = "garrow_vehicle_elevator_one"
 	},
 /turf/open/floor/almayer/black/north,
 /area/golden_arrow/vehicle_shuttle/upper)
+"ahG" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/window/reinforced/ultra{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "ahH" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "N";
@@ -2648,12 +3669,59 @@
 /obj/structure/surface/table/almayer,
 /turf/open/floor/almayer,
 /area/golden_arrow/cryo_cells)
+"ahL" = (
+/obj/structure/pipes/vents/scrubber{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"ahM" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning";
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "ahN" = (
 /obj/structure/sign/safety/one{
 	pixel_x = 39
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/motor_pool)
+"ahO" = (
+/obj/structure/machinery/door/firedoor/border_only/almayer,
+/obj/structure/machinery/door/airlock/almayer/secure{
+	name = "\improper Muster Point Backroom";
+	req_access = list()
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"ahP" = (
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = -8;
+	pixel_y = 18
+	},
+/obj/structure/filingcabinet{
+	density = 0;
+	pixel_x = 8;
+	pixel_y = 18
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"ahQ" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/structure/machinery/alarm/almayer{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
 "ahR" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
@@ -2667,6 +3735,16 @@
 	},
 /turf/open/floor/almayer/edge/smooth/east,
 /area/golden_arrow/hangar)
+"ahS" = (
+/obj/structure/machinery/light/double/blue/golden_arrow{
+	dir = 8;
+	light_power = 0.7
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "ahT" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
@@ -2678,6 +3756,16 @@
 	},
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/hangar)
+"ahU" = (
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/obj/structure/prop/almayer/whiteboard/clear{
+	density = 0;
+	pixel_y = 18
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "ahV" = (
 /obj/structure/machinery/door/poddoor/almayer/locked{
 	name = "\improper Hangar Lockdown Blast Door";
@@ -2686,6 +3774,30 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer/test_floor4,
 /area/golden_arrow/lower_cargo)
+"ahW" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "cargo_arrow";
+	dir = 1
+	},
+/obj/structure/machinery/door_control{
+	name = "muster point door-control";
+	pixel_x = 23;
+	pixel_y = 12;
+	id = "musterdoor"
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"ahX" = (
+/obj/structure/surface/table/almayer,
+/obj/item/notepad,
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "ahY" = (
 /obj/structure/prop/invuln/lattice_prop{
 	icon_state = "lattice1";
@@ -2747,6 +3859,21 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/golden_arrow/hangar)
+"aie" = (
+/obj/structure/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/structure/surface/table/almayer,
+/obj/item/tool/pen,
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
+"aif" = (
+/obj/structure/sign/banners/brazil_flag{
+	pixel_x = -12;
+	pixel_y = 30
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "aig" = (
 /obj/structure/machinery/door_control{
 	name = "cargobay3";
@@ -2799,6 +3926,12 @@
 	},
 /turf/open/floor/almayer/edge/northeast,
 /area/golden_arrow/dorms)
+"aik" = (
+/obj/structure/sign/banners/united_americas_flag{
+	pixel_y = 30
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "ail" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -2808,6 +3941,38 @@
 	},
 /turf/open/floor/almayer/test_floor4,
 /area/golden_arrow/platoonprep)
+"aim" = (
+/obj/structure/machinery/door/poddoor/shutters/almayer/open{
+	id = "musterdoor"
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/briefing)
+"ain" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "cargo_arrow"
+	},
+/obj/structure/machinery/door_control{
+	name = "muster point door-control";
+	pixel_x = 23;
+	pixel_y = -6;
+	id = "musterdoor"
+	},
+/turf/open/floor/almayer,
+/area/golden_arrow/briefing)
+"aio" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/structure/machinery/light/double/blue/golden_arrow{
+	dir = 4;
+	light_power = 0.7
+	},
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/port_hallway)
 "aiq" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -4151,6 +5316,9 @@
 /turf/open/floor/almayer/edge/east,
 /area/golden_arrow/supply)
 "anb" = (
+/obj/structure/machinery/light/double/blue/golden_arrow{
+	light_power = 0.5
+	},
 /turf/open/floor/almayer/edge/smooth/corner/west,
 /area/golden_arrow/briefing)
 "anc" = (
@@ -6197,9 +7365,6 @@
 	},
 /turf/open/floor/almayer,
 /area/golden_arrow/motor_pool)
-"auh" = (
-/turf/closed/wall/almayer/outer,
-/area/golden_arrow/prep_hallway)
 "auk" = (
 /turf/open/floor/almayer,
 /area/golden_arrow/platoon_commander_rooms)
@@ -6294,8 +7459,11 @@
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
 	},
-/turf/open/floor/almayer,
-/area/golden_arrow/prep_hallway)
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/edge/west,
+/area/golden_arrow/port_hallway)
 "auG" = (
 /obj/structure/platform{
 	dir = 8;
@@ -6564,13 +7732,13 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/structure/machinery/door/poddoor/almayer/locked{
+/obj/structure/machinery/door/poddoor/almayer/open{
 	name = "\improper Hangar Lockdown Blast Door";
 	dir = 2;
 	id = "hangarlockdownwest"
 	},
 /turf/open/floor/almayer/test_floor4,
-/area/golden_arrow/prep_hallway)
+/area/golden_arrow/port_hallway)
 "avT" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
@@ -8637,13 +9805,6 @@
 	},
 /turf/open/floor/almayer/black/east,
 /area/golden_arrow/vehicle_shuttle/upper)
-"aBN" = (
-/obj/structure/machinery/door/poddoor/almayer/locked{
-	name = "\improper Hangar Lockdown Blast Door";
-	dir = 2
-	},
-/turf/open/floor/almayer,
-/area/golden_arrow/prep_hallway)
 "aBO" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
@@ -13533,13 +14694,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/golden_arrow/briefing)
 "aTc" = (
-/obj/structure/machinery/door/poddoor/almayer/locked{
+/obj/structure/machinery/door/poddoor/almayer/open{
 	name = "\improper Hangar Lockdown Blast Door";
 	dir = 2;
 	id = "hangarlockdownwest"
 	},
 /turf/open/floor/almayer/test_floor4,
-/area/golden_arrow/prep_hallway)
+/area/golden_arrow/port_hallway)
 "aTe" = (
 /obj/structure/roof/cargocrane_tracks/horizontal/endcap1{
 	pixel_y = 14
@@ -14126,7 +15287,7 @@
 /obj/effect/landmark/nightmare{
 	insert_tag = "medbay"
 	},
-/turf/closed/wall/almayer/outer,
+/turf/closed/wall/almayer,
 /area/golden_arrow/medical)
 "aVi" = (
 /obj/effect/decal/cleanable/dirt{
@@ -14417,8 +15578,11 @@
 	dir = 8;
 	light_power = 0.7
 	},
-/turf/open/floor/almayer,
-/area/golden_arrow/prep_hallway)
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/turf/open/floor/almayer/edge/west,
+/area/golden_arrow/port_hallway)
 "aWj" = (
 /obj/effect/decal/cleanable/dirt{
 	layer = 2.52
@@ -14955,8 +16119,15 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/turf/open/floor/almayer/cargo_arrow/north,
-/area/golden_arrow/prep_hallway)
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "cargo_arrow";
+	dir = 1
+	},
+/turf/open/floor/almayer/edge/northeast,
+/area/golden_arrow/port_hallway)
 "aYl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -16527,7 +17698,7 @@
 	icon_state = "wallpipe_2";
 	pixel_y = 31
 	},
-/turf/closed/wall/almayer/outer,
+/turf/closed/wall/almayer,
 /area/golden_arrow/briefing)
 "eGR" = (
 /turf/open/floor/plating/plating_catwalk,
@@ -19315,9 +20486,6 @@
 	phone_category = "Golden Arrow";
 	phone_id = "Briefing"
 	},
-/obj/structure/machinery/light/double/blue/golden_arrow{
-	light_power = 0.5
-	},
 /turf/open/floor/almayer,
 /area/golden_arrow/briefing)
 "oRK" = (
@@ -20847,11 +22015,14 @@
 /turf/open/floor/almayer,
 /area/golden_arrow/lower_cargo)
 "vbQ" = (
+/obj/effect/decal/cleanable/dirt{
+	layer = 2.52
+	},
 /obj/effect/landmark/nightmare{
 	insert_tag = "briefing"
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/almayer,
+/area/golden_arrow/port_hallway)
 "vfK" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/reagentgrinder/industrial{
@@ -24848,13 +26019,13 @@ aEG
 aEG
 aEG
 aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+abP
+abP
+abP
+abP
+abP
+abP
+abP
 aEG
 aEG
 aEG
@@ -25025,13 +26196,13 @@ aEG
 aEG
 aEG
 aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+abP
+agU
+aga
+aft
+aeP
+adN
+abP
 aEG
 aEG
 aEG
@@ -25202,13 +26373,13 @@ aEG
 aEG
 aEG
 aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+abP
+adO
+agg
+aft
+aeS
+adO
+abP
 aEG
 aEG
 aEG
@@ -25379,13 +26550,13 @@ aEG
 aEG
 aEG
 aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+abP
+adO
+agi
+aft
+aeY
+adO
+abP
 aEG
 aEG
 aEG
@@ -25556,13 +26727,13 @@ aEG
 aEG
 aEG
 aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+abP
+agW
+agk
+aee
+afa
+adR
+abP
 aEG
 aEG
 aEG
@@ -25733,13 +26904,13 @@ aEG
 aEG
 aEG
 aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+abP
+adO
+agg
+aft
+aeS
+adO
+abP
 aEG
 aEG
 aEG
@@ -25910,13 +27081,13 @@ aEG
 aEG
 aEG
 aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+abP
+adS
+agl
+aft
+afb
+adS
+abP
 aEG
 aEG
 aEG
@@ -26087,13 +27258,13 @@ aEG
 aEG
 aEG
 aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+abP
+agZ
+agm
+afw
+afc
+adX
+abP
 aEG
 aEG
 aEG
@@ -26264,14 +27435,14 @@ aEG
 aEG
 aEG
 aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+abP
+ahd
+afe
+aft
+afe
+adY
+abP
+abP
 aEG
 aEG
 aEG
@@ -26441,14 +27612,14 @@ aEG
 aEG
 aEG
 aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+abP
+ahe
+afg
+afC
+afg
+adZ
+acN
+abP
 aEG
 aEG
 aEG
@@ -26618,14 +27789,14 @@ aEG
 aRI
 aEG
 aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+abP
+ahf
+agn
+afE
+afi
+aee
+acU
+abP
 aEG
 aEG
 aEG
@@ -26790,24 +27961,24 @@ abx
 acQ
 abx
 avb
-auh
-auh
-auh
-auh
-auh
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+abP
+abP
+abP
+abP
+abP
+abP
+ahh
+agp
+acW
+acW
+acW
+acW
+abP
+abP
+abP
+abP
+abP
+abP
 aEG
 aEG
 aEG
@@ -26971,20 +28142,20 @@ aTc
 aer
 aWi
 auE
-aBN
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+acY
+acY
+ahn
+agr
+afF
+acm
+aeh
+acY
+acE
+acm
+acj
+acf
+acc
+abU
 aEG
 aEG
 aEG
@@ -27146,22 +28317,22 @@ aGT
 aiU
 avO
 aYk
-aGT
+aio
 agR
-aBN
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+ags
+ahQ
+ahq
+ags
+acl
+afj
+aei
+adb
+acF
+acn
+acl
+acg
+acd
+abZ
 aEG
 aEG
 aEG
@@ -27321,24 +28492,24 @@ rPa
 rPa
 rPa
 rPa
-auh
-auh
-auh
-auh
-auh
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+acW
+acW
+acW
+acW
+acW
+acW
+acW
+acW
+acW
+acW
+aem
+adc
+abP
+abP
+abP
+abP
+abP
+abP
 aEG
 aEG
 aEG
@@ -27499,18 +28670,18 @@ aEh
 aCE
 aDO
 vtV
-aaI
+aCE
 aVg
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+acW
+acW
+acW
+ahr
+agt
+afG
+acW
+aep
+ade
+abP
 aEG
 aEG
 aEG
@@ -27677,17 +28848,17 @@ acH
 aoe
 jVu
 hRK
-aaI
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aCE
+acW
+acW
+acW
+ahs
+agu
+afH
+afp
+aeq
+ade
+abP
 aEG
 aEG
 aEG
@@ -27854,17 +29025,17 @@ aCE
 aed
 rAj
 nLR
-aaI
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aCE
+acW
+acW
+acW
+ahu
+acu
+afK
+acW
+aes
+adh
+abP
 aEG
 aEG
 aEG
@@ -28031,17 +29202,17 @@ aCE
 anM
 akY
 aQI
-aaI
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aCE
+acW
+acW
+acW
+ahv
+agw
+afM
+afr
+aet
+ade
+abP
 aEG
 aEG
 aEG
@@ -28208,17 +29379,17 @@ aCE
 aXk
 cUK
 aIu
-aaI
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aCE
+acW
+acW
+acW
+ahx
+agx
+afS
+afr
+aeu
+adi
+abP
 aEG
 aEG
 aEG
@@ -28385,17 +29556,17 @@ aCE
 aCE
 aHp
 aCE
-aaI
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aCE
+acW
+acW
+acW
+acW
+acW
+acW
+acW
+aew
+adm
+abP
 aEG
 aEG
 aEG
@@ -28562,17 +29733,17 @@ aKW
 pKQ
 aVT
 ans
-aaI
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aCE
+acW
+acW
+acW
+acW
+acW
+acW
+acW
+aex
+ads
+abP
 aEG
 aEG
 aEG
@@ -28739,19 +29910,19 @@ ayf
 atv
 aBv
 akT
-aaI
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aCE
+acW
+acW
+acW
+acW
+acW
+acW
+acW
+aeB
+adu
+abP
+abP
+abP
 aEG
 aEG
 aEG
@@ -28916,19 +30087,19 @@ afX
 akY
 ikK
 aCE
-aaI
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aCE
+acW
+ahX
+ahS
+acy
+agz
+acy
+acy
+aeD
+adw
+acy
+acp
+abP
 aEG
 aEG
 aEG
@@ -29093,19 +30264,19 @@ aIy
 pZI
 aBv
 aNI
-aaI
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aCE
+acW
+aie
+acy
+ahy
+acy
+acy
+acu
+aeI
+acy
+acG
+acu
+abP
 aEG
 aEG
 aEG
@@ -29270,19 +30441,19 @@ aNY
 olG
 wYO
 aPm
-aaI
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aCE
+acW
+aif
+acu
+ahC
+agA
+acu
+aeN
+acI
+adF
+acI
+acy
+abP
 aEG
 aEG
 aEG
@@ -29447,19 +30618,19 @@ aCE
 aCE
 aCE
 aCE
-aaI
-awL
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aCE
+acW
+aik
+acu
+ahD
+agF
+afV
+adM
+aeJ
+adM
+acJ
+acy
+abP
 aEG
 aEG
 aEG
@@ -29625,18 +30796,18 @@ aeQ
 aXH
 abz
 ayo
-awL
+aEo
 vbQ
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+acu
+ahE
+agJ
+acy
+adF
+aeN
+adF
+acI
+acy
+abP
 aEG
 aEG
 aEG
@@ -29802,18 +30973,18 @@ anE
 jXa
 azs
 ewl
-awL
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aEo
+acy
+acy
+ahG
+agK
+acy
+aeN
+aeN
+adF
+acK
+acy
+abP
 aEG
 aEG
 aEG
@@ -29979,18 +31150,18 @@ ptZ
 afv
 pvV
 alp
-awL
-awL
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aEo
+aEo
+ahU
+ahL
+acu
+acu
+acu
+acy
+acy
+acM
+acy
+abP
 aEG
 aEG
 aEG
@@ -30157,17 +31328,17 @@ afP
 gGG
 alp
 aat
-awL
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aEo
+acu
+ahM
+acC
+afY
+acu
+acu
+acy
+acy
+acC
+abP
 aEG
 aEG
 aEG
@@ -30334,17 +31505,17 @@ aFA
 kNp
 alp
 hrh
-awL
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
-aEG
+aEo
+acW
+ahO
+acW
+abP
+abP
+abP
+abP
+abP
+abP
+abP
 aEG
 aEG
 aEG
@@ -30510,12 +31681,12 @@ gkz
 ayN
 hmW
 anb
-awL
-awL
-aEG
-aEG
-aEG
-aEG
+aEo
+aEo
+acW
+adw
+agL
+abP
 aEG
 aEG
 aEG
@@ -30687,12 +31858,12 @@ dSy
 hVV
 aKs
 oIL
-awL
-aEG
-aEG
-aEG
-aEG
-aEG
+ain
+aim
+ahW
+acy
+acy
+abP
 aEG
 aEG
 aEG
@@ -30864,12 +32035,12 @@ mEQ
 oFy
 fLv
 eGp
-awL
-awL
-aEG
-aEG
-aEG
-aEG
+aEo
+aEo
+acW
+ahP
+agQ
+abP
 aEG
 aEG
 aEG
@@ -31042,11 +32213,11 @@ fUj
 vFU
 azc
 azc
-awL
-aEG
-aEG
-aEG
-aEG
+aEo
+acW
+ahP
+acy
+abP
 aEG
 aEG
 aEG
@@ -31220,10 +32391,10 @@ aSV
 azc
 fUj
 awL
-aEG
-aEG
-aEG
-aEG
+abP
+abP
+abP
+abP
 aEG
 aEG
 aEG


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Expands Golden Arrow to the South, adding a port sector, which includes:
- Security Checkpoint.
- Shooting Range.
- Muster Point.

Mostly Fluff, but paves the way for further map expansion.

# Explain why it's good for the game

The server wants to host training matches, and the included rooms could be a good addition for that purpose.


# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

<img width="549" height="443" alt="image" src="https://github.com/user-attachments/assets/95227d4e-03f9-4dc5-884f-ba46ad03e02c" />
<img width="426" height="502" alt="image" src="https://github.com/user-attachments/assets/5db2954b-6e4f-46af-b14b-4cc2a451e893" />


</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
mapadd: added a south (port) section in golden arrow map.
:cl:
