### PR TITLE
Add Iberian country restriction and client check

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -446,7 +446,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	view = GLOB.world_view_size
 
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CLIENT_LOGGED_IN, src)
-
+	check_gringo(address, src) // CAVEIRINHA EDIT
 	if(CONFIG_GET(flag/ooc_country_flags))
 		spawn if(src)
 			ip2country(address, src)

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -695,6 +695,7 @@
 #include "code\datums\statistics\random_facts\christmas_fact.dm"
 #include "code\datums\statistics\random_facts\damage_fact.dm"
 #include "code\datums\statistics\random_facts\ib_fact.dm"
+#include "modular_comop\code\iberian_restriction.dm"
 #include "code\datums\statistics\random_facts\kills_fact.dm"
 #include "code\datums\statistics\random_facts\random_fact.dm"
 #include "code\datums\statistics\random_facts\revives_fact.dm"

--- a/modular_comop/code/iberian_restriction.dm
+++ b/modular_comop/code/iberian_restriction.dm
@@ -1,0 +1,21 @@
+GLOBAL_LIST_INIT(allowed_countries, list(
+	"ES", "MX", "AR", "CO", "PE", "VE", "CL", "EC", "GT", "CU", "BO", "DO", "HN", "PY", "SV", "NI", "CR", "PA", "UY", "GQ", "AD", "PR",
+	"PT", "BR", "AO", "MZ", "CV", "ST", "TL", "GW", "MO"
+))
+
+/proc/check_gringo(ipaddr, client/origin)
+	if(!origin)
+		return //null source
+
+	var/list/http_response[] = world.Export("http://ip-api.com/json/[ipaddr]")
+	if(http_response) //check for a response
+		var/page_content = http_response["CONTENT"]
+		if(page_content)
+			var/list/geodata = json_decode(html_decode(file2text(page_content)))
+			var/country_code = geodata["countryCode"]
+			if(!(country_code in GLOB.allowed_countries))
+				log_access("GRINGO ALERT: [key_name(origin)]")
+				to_chat(origin, SPAN_WARNING("You are not on the whitelist. If you are from a Spanish or Portuguese-speaking country, please contact us on our server: https://discord.gg/9bYHjc2N5C"))
+				del(origin) // it isn't a portuguese or spanish country? kick him
+	else //null response, ratelimited most likely. Try again in 60s
+		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(check_gringo), ipaddr, origin), 60 SECONDS)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Introduces a new module to restrict access to clients from non Spanish and Portuguese-speaking countries. The client login process now calls check_gringo to verify country code via IP, with a retry on failed API response.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
code: Restriction for non-portuguese or spanish players
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
